### PR TITLE
recommended products and same user issue

### DIFF
--- a/bangazon_api/migrations/0003_auto_20211202_1736.py
+++ b/bangazon_api/migrations/0003_auto_20211202_1736.py
@@ -32,5 +32,5 @@ class Migration(migrations.Migration):
             model_name='recommendation',
             name='recommender',
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='recommended_by', to=settings.AUTH_USER_MODEL),
-        ),
+        )
     ]

--- a/bangazon_api/models/product.py
+++ b/bangazon_api/models/product.py
@@ -28,7 +28,6 @@ class Product(models.Model):
         Returns:
             number -- The average rating for the product
         """
-        # TODO: Fix Divide by zero error
 
         total_rating = 0
         for rating in self.ratings.all():

--- a/bangazon_api/serializers/user_serializer.py
+++ b/bangazon_api/serializers/user_serializer.py
@@ -6,7 +6,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username', 'first_name', 'last_name', 'orders',
-                  'favorites', 'store', 'recommended_by')
+                  'favorites', 'store', 'recommended_by', 'recommendations')
         depth = 1
 
 

--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.get(username=request.auth.user))
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Issue #2 & #23 

Modified Files: 
user_serializer.py - line 9 - added recommendtions field. 
profile_view.py - line 31 - changed getAll to get username=request.auth.user 

Directions: 
1. checkout to lz-recommendedProducts 
2. runserver 
3. go to https://nss-bangazon-dev.herokuapp.com/products/2 
4. try to login as a different user, see if successful on the network and applications tab. 
5. go to http://localhost:8000/swagger/
6. go to get profile/my-profile and execute 
7. see if recommendations and recommended-by arrays show up. 